### PR TITLE
I2c improvements

### DIFF
--- a/examples/bh1750_example/rebar.config
+++ b/examples/bh1750_example/rebar.config
@@ -5,3 +5,6 @@
 {plugins, [
     atomvm_rebar3_plugin
 ]}.
+{atomvm_rebar3_plugin, [
+    {packbeam, [prune]}
+]}.

--- a/examples/bh1750_example/src/bh1750_example.erl
+++ b/examples/bh1750_example/src/bh1750_example.erl
@@ -37,7 +37,7 @@ start() ->
 one_time_loop(BH) ->
     case bh1750:take_reading(BH) of
         {ok, Reading} ->
-            io:format("Luminosity: ~slx\n", [to_string(Reading)]);
+            io:format("Luminosity: ~slx\n", [Reading]);
         ErrorT ->
             io:format("Error taking reading temperature: ~p~n", [ErrorT])
     end,
@@ -47,9 +47,6 @@ one_time_loop(BH) ->
 continuous_loop(BH) ->
     receive
         Reading ->
-            io:format("Luminosity: ~slx\n", [to_string(Reading)])
+            io:format("Luminosity: ~p\n", [Reading])
     end,
     continuous_loop(BH).
-
-to_string({Integral, {Fractional, _}}) ->
-    io_lib:format("~p.~p", [Integral, Fractional]).

--- a/examples/bme280_example/rebar.config
+++ b/examples/bme280_example/rebar.config
@@ -5,3 +5,6 @@
 {plugins, [
     atomvm_rebar3_plugin
 ]}.
+{atomvm_rebar3_plugin, [
+    {packbeam, [prune]}
+]}.

--- a/examples/sht3x_example/rebar.config
+++ b/examples/sht3x_example/rebar.config
@@ -5,3 +5,6 @@
 {plugins, [
     atomvm_rebar3_plugin
 ]}.
+{atomvm_rebar3_plugin, [
+    {packbeam, [prune]}
+]}.

--- a/src/bh1750.erl
+++ b/src/bh1750.erl
@@ -31,8 +31,24 @@
 
 -behaviour(gen_server).
 
--export([start/1, start/2, stop/1, take_reading/1, reset/1]).
--export([init/1, handle_call/3, handle_cast/2, handle_info/2, terminate/2, code_change/3]).
+-export([
+    start/1,
+    start/2,
+    start_link/1,
+    start_link/2,
+    stop/1,
+    take_reading/1,
+    reset/1
+]).
+
+-export([
+    init/1,
+    handle_call/3,
+    handle_cast/2,
+    handle_info/2,
+    terminate/2,
+    code_change/3]
+).
 
 % -define(TRACE_ENABLED, true).
 -include_lib("atomvm_lib/include/trace.hrl").
@@ -113,6 +129,47 @@ start(I2CBus) ->
 -spec start(I2CBus::i2c_bus:i2c_bus(), Options::options()) -> {ok, BH::bh()} | {error, Reason::term()}.
 start(I2CBus, Options) ->
     case gen_server:start(?MODULE, {I2CBus, maybe_add_self(Options)}, []) of
+        {ok, Pid} = R ->
+            maybe_start_continuous(Pid, Options),
+            R;
+        E -> E
+    end.
+
+%%-----------------------------------------------------------------------------
+%% @param   SDAPin pin number for I2C SDA channel
+%% @param   SCLPin pin number for the I2C SCL channel
+%% @returns {ok, BH} on success, or {error, Reason}, on failure
+%% @equiv   start_link(SDAPin, SCLPin, [])
+%% @doc     Start the BH1750 driver.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start_link(I2CBus::i2c_bus:i2c_bus()) -> {ok, BH::bh()} | {error, Reason::term()}.
+start_link(I2CBus) ->
+    start_link(I2CBus, []).
+
+%%-----------------------------------------------------------------------------
+%% @param   SDAPin pin number for I2C SDA channel
+%% @param   SCLPin pin number for the I2C SCL channel
+%% @param   Options additional driver options
+%% @returns {ok, BH} on success, or {error, Reason}, on failure
+%% @doc     Start the BH1750 driver.
+%%
+%% This operation will start the BH driver.  Use the returned reference
+%% in subsequent operations, such as for taking a reading.
+%%
+%% The Options parameter may be used to fine-tune behavior of the sensor,
+%% but the default values should be sufficient for weather-station based
+%% scenarios.
+%%
+%% Notes:  The default oversampling rates for temperature, pressure, and humidity
+%% is `x4'.  A sampling rate of `ignore' is not tested.
+%%
+%% The default `mode' is `forced'.  Other modes are not tested.
+%% @end
+%%-----------------------------------------------------------------------------
+-spec start_link(I2CBus::i2c_bus:i2c_bus(), Options::options()) -> {ok, BH::bh()} | {error, Reason::term()}.
+start_link(I2CBus, Options) ->
+    case gen_server:start_link(?MODULE, {I2CBus, maybe_add_self(Options)}, []) of
         {ok, Pid} = R ->
             maybe_start_continuous(Pid, Options),
             R;

--- a/src/sht3x.erl
+++ b/src/sht3x.erl
@@ -248,18 +248,7 @@ do_take_reading(State) ->
     %%
     {MSB, LSB} = create_measurement_command(State#state.options),
     ?TRACE("measurement_command: ~p", [{MSB, LSB}]),
-    ok = i2c_bus:enqueue(
-        I2CBus, ?SHT31_BASE_ADDR, [
-            fun(Port, _Address) ->
-                ?TRACE("writing ~p", [MSB]),
-                ok = i2c:write_byte(Port, MSB)
-            end,
-            fun(Port, _Address) ->
-                ?TRACE("writing ~p", [LSB]),
-                ok = i2c:write_byte(Port, LSB)
-            end
-        ]
-    ),
+    ok = i2c_bus:write_bytes(I2CBus, ?SHT31_BASE_ADDR, <<MSB:8, LSB:8>>),
     timer:sleep(20),
     %%
     %% Read the data in memory.


### PR DESCRIPTION
This PR contains sever improvements to the SHT3x, BME280, and BH1750 I2C drivers, in addition to the i2c_bus.

The following high level changes are made:

* All drivers now use atomic i2c functions, instead of enqueuing calls to be wrapped in begin/end transmission.  This results in fewer calls to the I2C driver
* BREAKING CHANGE: The BH1750 measurement values are now floats, instead of rationals.  This follows previous changes to the SHT3x and BME280 drivers.  (All of these drivers were written before floating point support in AtomVM)
* Misc cosmetic naming changes to make the code more consistent.
* Added start_link functions to the BH1750 driver, for completeness.
* Updates to the rebar.confg files in the I2C examples to align with latest rebar plugin behavior

Tested with the forthcoming resource-based Nif driver.