### PR TITLE
IDFv5.x support

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -28,7 +28,17 @@ idf_component_register(
     PRIV_REQUIRES "libatomvm" "avm_sys" "mbedtls"
 )
 
-idf_build_set_property(
-    LINK_OPTIONS "-Wl,--whole-archive ${CMAKE_CURRENT_BINARY_DIR}/lib${COMPONENT_NAME}.a -Wl,--no-whole-archive"
-    APPEND
-)
+# WHOLE_ARCHIVE option is supported only with esp-idf 5.x
+if (IDF_VERSION_MAJOR EQUAL 5)
+    set(OPTIONAL_WHOLE_ARCHIVE WHOLE_ARCHIVE)
+else()
+    set(OPTIONAL_WHOLE_ARCHIVE "")
+endif()
+
+# A link option is required with esp-idf 4.x
+if (IDF_VERSION_MAJOR EQUAL 4)
+    idf_build_set_property(
+        LINK_OPTIONS "-Wl,--whole-archive ${CMAKE_CURRENT_BINARY_DIR}/lib${COMPONENT_NAME}.a -Wl,--no-whole-archive"
+        APPEND
+    )
+endif()

--- a/examples/application_example/rebar.config
+++ b/examples/application_example/rebar.config
@@ -1,5 +1,9 @@
 {erl_opts, [debug_info]}.
-{deps, [{atomvm_lib, {git, "https://github.com/fadushin/atomvm_lib.git", {branch, "master"}}}]}.
+{deps, [{atomvm_lib, {git, "https://github.com/atomvm/atomvm_lib.git", {branch, "master"}}}]}.
 {plugins, [
     atomvm_rebar3_plugin
+]}.
+]}.
+{atomvm_rebar3_plugin, [
+    {packbeam, [prune]}
 ]}.

--- a/nifs/atomvm_lib.c
+++ b/nifs/atomvm_lib.c
@@ -104,7 +104,11 @@ static term nif_sha1(Context *ctx, int argc, term argv[])
     term ret = term_create_uninitialized_binary(SHA1_LEN, &ctx->heap, ctx->global);
     binary = argv[0];
 
+    #if ESP_IDF_VERSION_MAJOR >= 5
+    int res = mbedtls_sha1((const unsigned char *) term_binary_data(binary), term_binary_size(binary), (unsigned char *) term_binary_data(ret));
+    #else
     int res = mbedtls_sha1_ret((const unsigned char *) term_binary_data(binary), term_binary_size(binary), (unsigned char *) term_binary_data(ret));
+    #endif
     if (res != 0) {
         RAISE_ERROR(BADARG_ATOM);
     }


### PR DESCRIPTION
Adds support for building with all current Espressif supported ESP-IDF versions.