### PR TITLE
Updates links to use atomvm.org

### DIFF
--- a/examples/lora_example/README.md
+++ b/examples/lora_example/README.md
@@ -15,7 +15,7 @@ For this application, you will need:
 
 While the [IDF SDK](https://docs.espressif.com/projects/esp-idf/en/latest/esp32/) and required tool-chains are not required, they may make life a little easier.
 
-> Note.  These instructions assume you have flashed the AtomVM virtual machine and Erlang libraries to your ESP32 device.  For information about flashing ESP32 devices with the AtomVM virtual machine and libraries, consult the [AtomVM documentation](https://doc.atomvm.net).
+> Note.  These instructions assume you have flashed the AtomVM virtual machine and Erlang libraries to your ESP32 device.  For information about flashing ESP32 devices with the AtomVM virtual machine and libraries, consult the [AtomVM documentation](https://doc.atomvm.org/latest) [Getting Started on the ESP32 platform](https://doc.atomvm.org/latest/getting-started-guide.html#getting-started-on-the-esp32-platform) section.
 
 ## Getting Started
 

--- a/markdown/components.md
+++ b/markdown/components.md
@@ -13,7 +13,7 @@ This page provides instructions for building and linking `atomvm_lib` components
 * [IDF SDK](https://docs.espressif.com/projects/esp-idf/en/release-v3.3/index.html) and tool chain, and its pre-requisite software.
 * [AtomVM](https://github.com/bettio/AtomVM) source tree, and its pre-requisite software.
 
-> Note. These instructions assume you have downloaded the AtomVM virtual machine and have the required software needed to build the VM, including the IDF SDK and tool chain.  Instructions for building AtomVM are outside of the scope of this document.  For information about how to build AtomVM targeted for the ESP32, see the [AtomVM Implementors Guide](http://doc.atomvm.net).
+> Note. These instructions assume you have downloaded the AtomVM virtual machine and have the required software needed to build the VM, including the IDF SDK and tool chain.  Instructions for building AtomVM are outside of the scope of this document.  For information about how to build AtomVM targeted for the ESP32, see the [AtomVM Build Instructions](https://doc.atomvm.org/latest/build-instructions.html#building-for-esp32).
 
 ## `atomvm_lib` Build Instructions
 
@@ -37,4 +37,4 @@ This step should create a new AtomVM image, with the `atomvm_lib` components lin
 
 Now that you have built an AtomVM VM image containing `atomvm_lib` components, you can now flash the AtomVM image to your device.
 
-> Note.  Flashing the AtomVM image, containing the AtomVM VM and core Erlang libraries is outside of the scope of this document.  For information about how to create an AtomVM image and flash it to an ESP32, see the [AtomVM Implementors Guide](http://doc.atomvm.net).
+> Note.  Flashing the AtomVM image, containing the AtomVM VM and core Erlang libraries is outside of the scope of this document.  For information about how to create an AtomVM image and flash it to an ESP32, see the [AtomVM Getting Started](https://doc.atomvm.org/latest/getting-started-guide.html#getting-started-on-the-esp32-platform) chapter of the documentation.


### PR DESCRIPTION
Updates links to use the new atomvm.org domains and updates some to direct to the correct sections of the documentation when they are referenced.